### PR TITLE
feat: 관심 분야로 멤버 목록을 조회할 수 있도록 쿼리 조건 추가

### DIFF
--- a/src/__test__/fixtures/domain.ts
+++ b/src/__test__/fixtures/domain.ts
@@ -1,8 +1,8 @@
 import { faker } from '@faker-js/faker';
-import { Profile } from '@sight/app/domain/user/model/Profile';
 
-import { User, UserConstructorParams } from '@sight/app/domain/user/model/User';
 import { UserState } from '@sight/app/domain/user/model/constant';
+import { Profile } from '@sight/app/domain/user/model/Profile';
+import { User, UserConstructorParams } from '@sight/app/domain/user/model/User';
 
 export function generateUser(params?: Partial<UserConstructorParams>): User {
   return new User({

--- a/src/__test__/fixtures/view.ts
+++ b/src/__test__/fixtures/view.ts
@@ -1,6 +1,8 @@
 import { faker } from '@faker-js/faker';
+
 import { UserListView } from '@sight/app/application/user/query/view/UserListView';
 import { UserView } from '@sight/app/application/user/query/view/UserView';
+
 import { UserState } from '@sight/app/domain/user/model/constant';
 
 export function generateUserView(params?: Partial<UserView>): UserView {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,9 +1,8 @@
 import { Module } from '@nestjs/common';
-import { AppService } from '@sight/app/app.service';
 
 @Module({
   imports: [],
   controllers: [],
-  providers: [AppService],
+  providers: [],
 })
 export class AppModule {}

--- a/src/app/application/user/query/IUserQuery.ts
+++ b/src/app/application/user/query/IUserQuery.ts
@@ -1,8 +1,10 @@
 import { UserListView } from '@sight/app/application/user/query/view/UserListView';
+
 import { UserState } from '@sight/app/domain/user/model/constant';
 
 export type ListUserParams = {
   state: UserState | null;
+  interest: string | null;
   limit: number;
   offset: number;
 };

--- a/src/app/application/user/query/listUser/ListUserQuery.ts
+++ b/src/app/application/user/query/listUser/ListUserQuery.ts
@@ -1,9 +1,11 @@
 import { IQuery } from '@nestjs/cqrs';
+
 import { UserState } from '@sight/app/domain/user/model/constant';
 
 export class ListUserQuery implements IQuery {
   constructor(
     readonly state: UserState | null,
+    readonly interest: string | null,
     readonly limit: number,
     readonly offset: number,
   ) {}

--- a/src/app/application/user/query/listUser/ListUserQueryHandler.spec.ts
+++ b/src/app/application/user/query/listUser/ListUserQueryHandler.spec.ts
@@ -1,11 +1,13 @@
 import { Test } from '@nestjs/testing';
 
-import { ListUserQueryHandler } from '@sight/app/application/user/query/listUser/ListUserQueryHandler';
-import { IUserQuery } from '@sight/app/application/user/query/IUserQuery';
-import { ListUserQueryResult } from './ListUserQueryResult';
 import { ViewFixture } from '@sight/__test__/fixtures';
-import { UserListView } from '../view/UserListView';
-import { ListUserQuery } from './ListUserQuery';
+
+import { IUserQuery } from '@sight/app/application/user/query/IUserQuery';
+import { ListUserQuery } from '@sight/app/application/user/query/listUser/ListUserQuery';
+import { ListUserQueryHandler } from '@sight/app/application/user/query/listUser/ListUserQueryHandler';
+import { ListUserQueryResult } from '@sight/app/application/user/query/listUser/ListUserQueryResult';
+import { UserListView } from '@sight/app/application/user/query/view/UserListView';
+
 import { UserState } from '@sight/app/domain/user/model/constant';
 
 describe('ListUserQueryHandler', () => {
@@ -25,6 +27,7 @@ describe('ListUserQueryHandler', () => {
     let listView: UserListView;
 
     const state = UserState.UNDERGRADUATE;
+    const interest = '관심사';
     const limit = 5;
     const offset = 0;
 
@@ -34,20 +37,21 @@ describe('ListUserQueryHandler', () => {
     });
 
     test('파라미터를 의도대로 쿼리에 넘겨주어야 한다', async () => {
-      const query = new ListUserQuery(state, limit, offset);
+      const query = new ListUserQuery(state, interest, limit, offset);
 
       await listUserQueryHandler.execute(query);
 
       expect(userQuery.listUser).toBeCalledTimes(1);
       expect(userQuery.listUser).toBeCalledWith({
         state,
+        interest,
         limit,
         offset,
       });
     });
 
     test('유저 목록 뷰를 의도대로 반환해야 한다', async () => {
-      const query = new ListUserQuery(state, limit, offset);
+      const query = new ListUserQuery(state, interest, limit, offset);
 
       const queryResult = await listUserQueryHandler.execute(query);
 

--- a/src/app/application/user/query/listUser/ListUserQueryHandler.ts
+++ b/src/app/application/user/query/listUser/ListUserQueryHandler.ts
@@ -1,9 +1,9 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 
+import { IUserQuery } from '@sight/app/application/user/query/IUserQuery';
 import { ListUserQuery } from '@sight/app/application/user/query/listUser/ListUserQuery';
 import { ListUserQueryResult } from '@sight/app/application/user/query/listUser/ListUserQueryResult';
-import { IUserQuery } from '@sight/app/application/user/query/IUserQuery';
 
 @Injectable()
 @QueryHandler(ListUserQuery)
@@ -16,10 +16,11 @@ export class ListUserQueryHandler
   ) {}
 
   async execute(query: ListUserQuery): Promise<ListUserQueryResult> {
-    const { state, limit, offset } = query;
+    const { state, interest, limit, offset } = query;
 
     const listView = await this.userQuery.listUser({
       state,
+      interest,
       limit,
       offset,
     });

--- a/src/app/application/user/query/listUser/ListUserQueryResult.ts
+++ b/src/app/application/user/query/listUser/ListUserQueryResult.ts
@@ -1,4 +1,5 @@
 import { IQueryResult } from '@nestjs/cqrs';
+
 import { UserListView } from '@sight/app/application/user/query/view/UserListView';
 
 export class ListUserQueryResult implements IQueryResult {

--- a/src/app/domain/user/model/User.spec.ts
+++ b/src/app/domain/user/model/User.spec.ts
@@ -1,7 +1,7 @@
-import { User } from '@sight/app/domain/user/model/User';
-
 import { testNow } from '@sight/__test__/constant';
 import { DomainFixture } from '@sight/__test__/fixtures';
+
+import { User } from '@sight/app/domain/user/model/User';
 
 describe('User', () => {
   let user: User;

--- a/src/app/domain/user/model/User.ts
+++ b/src/app/domain/user/model/User.ts
@@ -1,5 +1,5 @@
-import { Profile } from '@sight/app/domain/user/model/Profile';
 import { UserState } from '@sight/app/domain/user/model/constant';
+import { Profile } from '@sight/app/domain/user/model/Profile';
 
 export type UserConstructorParams = {
   id: number;


### PR DESCRIPTION
### 주요 변경 사항
<!-- 해당 PR로 변경되는 사항을 한 눈에 알기 쉽게 정리해주세요. -->

관심 분야로 멤버 목록을 조회할 수 있도록 쿼리 조건으로 `interest`를 추가하였습니다.

또한, import 문에 대해 린트를 적용하였습니다.
그리고, `AppModule`에서 이미 삭제된 서비스인 `AppService`를 참조하는 부분을 수정하였습니다.

### 변경 이유
<!-- 변경이 일어나는 이유를 한 눈에 알기 쉽게 정리해주세요. -->

레거시에서 그러한 기능이 있습니다.
그 외 두 가지는 코드 정리 용도입니다.