### PR TITLE
feat: 관심 분야 도메인 추가 및 쿼리 추가

### DIFF
--- a/src/__test__/fixtures/domain.ts
+++ b/src/__test__/fixtures/domain.ts
@@ -3,6 +3,10 @@ import { faker } from '@faker-js/faker';
 import { UserState } from '@sight/app/domain/user/model/constant';
 import { Profile } from '@sight/app/domain/user/model/Profile';
 import { User, UserConstructorParams } from '@sight/app/domain/user/model/User';
+import {
+  Interest,
+  InterestConstructorParams,
+} from '@sight/app/domain/interest/model/Interest';
 
 export function generateUser(params?: Partial<UserConstructorParams>): User {
   return new User({
@@ -18,7 +22,6 @@ export function generateUser(params?: Partial<UserConstructorParams>): User {
       phone: faker.phone.number('###-####-####'),
       homepage: faker.internet.url(),
       language: faker.lorem.word(),
-      interest: faker.lorem.word(),
       prefer: faker.lorem.word(),
     }),
     admission: faker.lorem.word(),
@@ -35,6 +38,18 @@ export function generateUser(params?: Partial<UserConstructorParams>): User {
     lastEnterAt: faker.date.anytime(),
     createdAt: faker.date.anytime(),
     updatedAt: faker.date.anytime(),
+    ...params,
+  });
+}
+
+export function generateInterest(
+  params?: Partial<InterestConstructorParams>,
+): Interest {
+  return new Interest({
+    id: faker.number.int(),
+    name: faker.lorem.word(),
+    description: faker.lorem.paragraph(),
+    createdAt: faker.date.anytime(),
     ...params,
   });
 }

--- a/src/__test__/fixtures/view.ts
+++ b/src/__test__/fixtures/view.ts
@@ -1,5 +1,7 @@
 import { faker } from '@faker-js/faker';
 
+import { InterestListView } from '@sight/app/application/interest/query/view/InterestListView';
+import { InterestView } from '@sight/app/application/interest/query/view/InterestView';
 import { UserListView } from '@sight/app/application/user/query/view/UserListView';
 import { UserView } from '@sight/app/application/user/query/view/UserView';
 
@@ -19,7 +21,6 @@ export function generateUserView(params?: Partial<UserView>): UserView {
       phone: faker.phone.number('###-####-####'),
       homepage: faker.internet.url(),
       language: faker.lorem.word(),
-      interest: faker.lorem.word(),
       prefer: faker.lorem.word(),
     },
     admission: faker.lorem.word(),
@@ -48,6 +49,30 @@ export function generateUserListView(
   return {
     count,
     users: Array.from({ length: count }, () => generateUserView()),
+    ...params,
+  };
+}
+
+export function generateInterestView(
+  params?: Partial<InterestView>,
+): InterestView {
+  return {
+    id: faker.number.int(),
+    name: faker.lorem.word(),
+    description: faker.lorem.paragraph(),
+    createdAt: faker.date.anytime(),
+    ...params,
+  };
+}
+
+export function generateInterestListView(
+  params?: Partial<InterestListView>,
+): InterestListView {
+  const count = params?.count ?? faker.number.int({ min: 1, max: 5 });
+
+  return {
+    count,
+    interests: Array.from({ length: count }, () => generateInterestView()),
     ...params,
   };
 }

--- a/src/app/application/interest/query/IInterestQuery.ts
+++ b/src/app/application/interest/query/IInterestQuery.ts
@@ -1,0 +1,5 @@
+import { InterestListView } from '@sight/app/application/interest/query/view/InterestListView';
+
+export interface IInterestQuery {
+  listInterest(): Promise<InterestListView>;
+}

--- a/src/app/application/interest/query/listInterest/ListInterestQuery.ts
+++ b/src/app/application/interest/query/listInterest/ListInterestQuery.ts
@@ -1,0 +1,3 @@
+import { IQuery } from '@nestjs/cqrs';
+
+export class ListInterestQuery implements IQuery {}

--- a/src/app/application/interest/query/listInterest/ListInterestQueryHandler.spec.ts
+++ b/src/app/application/interest/query/listInterest/ListInterestQueryHandler.spec.ts
@@ -1,0 +1,40 @@
+import { Test } from '@nestjs/testing';
+
+import { ViewFixture } from '@sight/__test__/fixtures';
+
+import { IInterestQuery } from '@sight/app/application/interest/query/IInterestQuery';
+import { ListInterestQueryHandler } from '@sight/app/application/interest/query/listInterest/ListInterestQueryHandler';
+import { ListInterestQueryResult } from '@sight/app/application/interest/query/listInterest/listInterestQueryResult';
+import { InterestListView } from '@sight/app/application/interest/query/view/InterestListView';
+
+describe('ListInterestQueryHandler', () => {
+  let listInterestQueryHandler: ListInterestQueryHandler;
+  let interestQuery: IInterestQuery;
+
+  beforeAll(async () => {
+    const testModule = await Test.createTestingModule({
+      providers: [
+        ListInterestQueryHandler,
+        { provide: 'InterestQuery', useValue: {} },
+      ],
+    }).compile();
+
+    listInterestQueryHandler = testModule.get(ListInterestQueryHandler);
+    interestQuery = testModule.get('InterestQuery');
+  });
+
+  describe('execute', () => {
+    let listView: InterestListView;
+
+    beforeEach(() => {
+      listView = ViewFixture.generateInterestListView();
+      interestQuery.listInterest = jest.fn().mockResolvedValue(listView);
+    });
+
+    test('유저 목록 뷰를 의도대로 반환해야 한다', async () => {
+      const queryResult = await listInterestQueryHandler.execute();
+      const expected = new ListInterestQueryResult(listView);
+      expect(queryResult).toEqual(expected);
+    });
+  });
+});

--- a/src/app/application/interest/query/listInterest/ListInterestQueryHandler.ts
+++ b/src/app/application/interest/query/listInterest/ListInterestQueryHandler.ts
@@ -1,0 +1,22 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+
+import { IInterestQuery } from '@sight/app/application/interest/query/IInterestQuery';
+import { ListInterestQuery } from '@sight/app/application/interest/query/listInterest/ListInterestQuery';
+import { ListInterestQueryResult } from '@sight/app/application/interest/query/listInterest/listInterestQueryResult';
+
+@Injectable()
+@QueryHandler(ListInterestQuery)
+export class ListInterestQueryHandler
+  implements IQueryHandler<ListInterestQuery, ListInterestQueryResult>
+{
+  constructor(
+    @Inject('InterestQuery')
+    private readonly interestQuery: IInterestQuery,
+  ) {}
+
+  async execute(/* query: ListInterestQuery */): Promise<ListInterestQueryResult> {
+    const view = await this.interestQuery.listInterest();
+    return new ListInterestQueryResult(view);
+  }
+}

--- a/src/app/application/interest/query/listInterest/ListInterestQueryResult.ts
+++ b/src/app/application/interest/query/listInterest/ListInterestQueryResult.ts
@@ -1,0 +1,7 @@
+import { IQueryResult } from '@nestjs/cqrs';
+
+import { InterestListView } from '@sight/app/application/interest/query/view/InterestListView';
+
+export class ListInterestQueryResult implements IQueryResult {
+  constructor(readonly view: InterestListView) {}
+}

--- a/src/app/application/interest/query/view/InterestListView.ts
+++ b/src/app/application/interest/query/view/InterestListView.ts
@@ -1,0 +1,6 @@
+import { InterestView } from '@sight/app/application/interest/query/view/InterestView';
+
+export interface InterestListView {
+  count: number;
+  interests: InterestView[];
+}

--- a/src/app/application/interest/query/view/InterestView.ts
+++ b/src/app/application/interest/query/view/InterestView.ts
@@ -1,0 +1,6 @@
+export interface InterestView {
+  id: number;
+  name: string;
+  description: string;
+  createdAt: Date;
+}

--- a/src/app/application/user/query/view/UserView.ts
+++ b/src/app/application/user/query/view/UserView.ts
@@ -9,7 +9,6 @@ export interface ProfileView {
   phone: string | null;
   homepage: string | null;
   language: string | null;
-  interest: string | null;
   prefer: string | null;
 }
 

--- a/src/app/domain/interest/model/Interest.ts
+++ b/src/app/domain/interest/model/Interest.ts
@@ -1,0 +1,36 @@
+export type InterestConstructorParams = {
+  id: number;
+  name: string;
+  description: string;
+  createdAt: Date;
+};
+
+export class Interest {
+  private _id: number;
+  private _name: string;
+  private _description: string;
+  private _createdAt: Date;
+
+  constructor(params: InterestConstructorParams) {
+    this._id = params.id;
+    this._name = params.name;
+    this._description = params.description;
+    this._createdAt = params.createdAt;
+  }
+
+  get id(): number {
+    return this._id;
+  }
+
+  get name(): string {
+    return this._name;
+  }
+
+  get description(): string {
+    return this._description;
+  }
+
+  get createdAt(): Date {
+    return this._createdAt;
+  }
+}

--- a/src/app/domain/user/model/Profile.ts
+++ b/src/app/domain/user/model/Profile.ts
@@ -7,7 +7,6 @@ export type ProfileConstructorParams = {
   phone: string | null;
   homepage: string | null;
   language: string | null;
-  interest: string | null;
   prefer: string | null;
 };
 
@@ -20,7 +19,6 @@ export class Profile {
   private _phone: string | null;
   private _homepage: string | null;
   private _language: string | null;
-  private _interest: string | null;
   private _prefer: string | null;
 
   constructor(params: ProfileConstructorParams) {
@@ -32,7 +30,6 @@ export class Profile {
     this._phone = params.phone;
     this._homepage = params.homepage;
     this._language = params.language;
-    this._interest = params.interest;
     this._prefer = params.prefer;
   }
 
@@ -66,10 +63,6 @@ export class Profile {
 
   get language(): string | null {
     return this._language;
-  }
-
-  get interest(): string | null {
-    return this._interest;
   }
 
   get prefer(): string | null {


### PR DESCRIPTION
### 주요 변경 사항
<!-- 해당 PR로 변경되는 사항을 한 눈에 알기 쉽게 정리해주세요. -->

관심 분야 도메인(`Interest`)을 추가하였고, 관심 분야 목록 쿼리를 추가하였습니다.
그리고 유저의 필드에서 `interest`를 제거하였습니다. 이후 `UserInterest` 등의 이름을 가진 테이블로 연결할 예정입니다.

**후속 조치에 대한 관련 이슈**
- #9 

### 변경 이유
<!-- 변경이 일어나는 이유를 한 눈에 알기 쉽게 정리해주세요. -->

레거시 기능에 유저 수정 등에서 현재의 관심 분야 목록을 조회하는 파트가 있습니다. 이를 위해 사용합니다.
