### PR TITLE
chore: 커버리지 툴 변경

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions: write-all
 
     steps:
       - uses: actions/checkout@v3
       - uses: ArtiomTr/jest-coverage-report-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,14 @@
+name: Test coverage for pull request
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ArtiomTr/jest-coverage-report-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Test for merged commit
 
 on:
   push:
@@ -6,11 +6,6 @@ on:
       - 'docs/**'
     branches:
       - main
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
 
 jobs:
   build:
@@ -33,8 +28,4 @@ jobs:
             ${{ runner.OS }}-
 
       - run: npm ci
-      - run: npm run test:cov
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - run: npm run test

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,0 @@
-ignore:
-  - "**/*.module.ts"
-
-comment:
-  layout: "reach, diff, files"
-  behavior: default
-  require_changes: false
-  require_base: false
-  require_head: true

--- a/src/app/application/user/command/updateUser/UpdateUserCommand.ts
+++ b/src/app/application/user/command/updateUser/UpdateUserCommand.ts
@@ -1,0 +1,13 @@
+import { ICommand } from '@nestjs/cqrs';
+
+export class UpdateUserCommand implements ICommand {
+  constructor(
+    readonly userId: string,
+    readonly email: string,
+    readonly phone: string,
+    readonly homepage: string,
+    readonly languages: string[],
+    readonly interestIds: string[],
+    readonly prefer: string,
+  ) {}
+}


### PR DESCRIPTION
### 주요 변경 사항
<!-- 해당 PR로 변경되는 사항을 한 눈에 알기 쉽게 정리해주세요. -->

커버리지 툴을 codecov에서 [jest-coverage-report-action](https://github.com/ArtiomTr/jest-coverage-report-action)으로 변경합니다.

### 변경 이유
<!-- 변경이 일어나는 이유를 한 눈에 알기 쉽게 정리해주세요. -->

codecov는 시트가 많아지면 유료가 됩니다. 따라서 깃헙 액션 중 jest-coverage-report-action으로 대체합니다.