### PR TITLE
feat: 유저 정보 수정 커맨드 핸들러 구현

### DIFF
--- a/jest/setup.ts
+++ b/jest/setup.ts
@@ -1,6 +1,0 @@
-(() => {
-  const testNow = new Date(2023, 0, 1, 0, 0, 0, 0);
-
-  jest.useFakeTimers();
-  jest.setSystemTime(testNow);
-})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-prettier": "^5.0.0",
         "jest": "^29.5.0",
+        "jest-date-mock": "^1.0.8",
         "prettier": "^3.0.0",
         "source-map-support": "^0.5.21",
         "supertest": "^6.3.3",
@@ -6139,6 +6140,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/jest-date-mock": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/jest-date-mock/-/jest-date-mock-1.0.8.tgz",
+      "integrity": "sha512-0Lyp+z9xvuNmLbK+5N6FOhSiBeux05Lp5bbveFBmYo40Aggl2wwxFoIrZ+rOWC8nDNcLeBoDd2miQdEDSf3iQw==",
+      "dev": true
     },
     "node_modules/jest-diff": {
       "version": "29.6.2",
@@ -14029,6 +14036,12 @@
         "slash": "^3.0.0",
         "strip-json-comments": "^3.1.1"
       }
+    },
+    "jest-date-mock": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/jest-date-mock/-/jest-date-mock-1.0.8.tgz",
+      "integrity": "sha512-0Lyp+z9xvuNmLbK+5N6FOhSiBeux05Lp5bbveFBmYo40Aggl2wwxFoIrZ+rOWC8nDNcLeBoDd2miQdEDSf3iQw==",
+      "dev": true
     },
     "jest-diff": {
       "version": "29.6.2",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.0",
     "jest": "^29.5.0",
+    "jest-date-mock": "^1.0.8",
     "prettier": "^3.0.0",
     "source-map-support": "^0.5.21",
     "supertest": "^6.3.3",
@@ -72,9 +73,6 @@
     "testEnvironment": "node",
     "moduleNameMapper": {
       "@sight/(.*)": "<rootDir>/$1"
-    },
-    "setupFilesAfterEnv": [
-      "<rootDir>/../jest/setup.ts"
-    ]
+    }
   }
 }

--- a/src/__test__/constant/index.ts
+++ b/src/__test__/constant/index.ts
@@ -1,1 +1,0 @@
-export const testNow = new Date(2023, 0, 1, 0, 0, 0, 0);

--- a/src/__test__/fixtures/domain.ts
+++ b/src/__test__/fixtures/domain.ts
@@ -10,7 +10,7 @@ import {
 
 export function generateUser(params?: Partial<UserConstructorParams>): User {
   return new User({
-    id: faker.number.int(),
+    id: faker.string.uuid(),
     name: faker.lorem.word(),
     password: faker.lorem.word(),
     profile: new Profile({
@@ -21,7 +21,7 @@ export function generateUser(params?: Partial<UserConstructorParams>): User {
       email: faker.internet.email(),
       phone: faker.phone.number('###-####-####'),
       homepage: faker.internet.url(),
-      language: faker.lorem.word(),
+      languages: [faker.lorem.word()],
       prefer: faker.lorem.word(),
     }),
     admission: faker.lorem.word(),
@@ -46,7 +46,7 @@ export function generateInterest(
   params?: Partial<InterestConstructorParams>,
 ): Interest {
   return new Interest({
-    id: faker.number.int(),
+    id: faker.string.uuid(),
     name: faker.lorem.word(),
     description: faker.lorem.paragraph(),
     createdAt: faker.date.anytime(),

--- a/src/__test__/fixtures/view.ts
+++ b/src/__test__/fixtures/view.ts
@@ -9,7 +9,7 @@ import { UserState } from '@sight/app/domain/user/model/constant';
 
 export function generateUserView(params?: Partial<UserView>): UserView {
   return {
-    id: faker.number.int(),
+    id: faker.string.uuid(),
     name: faker.lorem.word(),
     password: faker.lorem.word(),
     profile: {
@@ -20,7 +20,7 @@ export function generateUserView(params?: Partial<UserView>): UserView {
       email: faker.internet.email(),
       phone: faker.phone.number('###-####-####'),
       homepage: faker.internet.url(),
-      language: faker.lorem.word(),
+      languages: [faker.lorem.word()],
       prefer: faker.lorem.word(),
     },
     admission: faker.lorem.word(),

--- a/src/app/application/user/command/updateUser/UpdateUserCommand.ts
+++ b/src/app/application/user/command/updateUser/UpdateUserCommand.ts
@@ -4,7 +4,7 @@ export class UpdateUserCommand implements ICommand {
   constructor(
     readonly userId: string,
     readonly email: string,
-    readonly phone: string,
+    readonly phone: string | null,
     readonly homepage: string,
     readonly languages: string[],
     readonly interestIds: string[],

--- a/src/app/application/user/command/updateUser/UpdateUserCommandHandler.spec.ts
+++ b/src/app/application/user/command/updateUser/UpdateUserCommandHandler.spec.ts
@@ -1,0 +1,173 @@
+import { Test } from '@nestjs/testing';
+import { advanceTo, clear } from 'jest-date-mock';
+
+import { Message } from '@sight/constant/message';
+import {
+  generateInterest,
+  generateUser,
+} from '@sight/__test__/fixtures/domain';
+
+import { UpdateUserCommand } from '@sight/app/application/user/command/updateUser/UpdateUserCommand';
+import { UpdateUserCommandHandler } from '@sight/app/application/user/command/updateUser/UpdateUserCommandHandler';
+import { UpdateUserCommandResult } from '@sight/app/application/user/command/updateUser/UpdateUserCommandResult';
+
+import { Interest } from '@sight/app/domain/interest/model/Interest';
+import { UserInterestFactory } from '@sight/app/domain/interest/UserInterestFactory';
+import { User } from '@sight/app/domain/user/model/User';
+import {
+  IInterestRepository,
+  InterestRepository,
+} from '@sight/app/domain/interest/IInterestRepository';
+import {
+  IUserInterestRepository,
+  UserInterestRepository,
+} from '@sight/app/domain/interest/IUserInterestRepository';
+import {
+  IUserRepository,
+  UserRepository,
+} from '@sight/app/domain/user/IUserRepository';
+import { UserState } from '@sight/app/domain/user/model/constant';
+
+describe('UpdateUserCommandHandler', () => {
+  let handler: UpdateUserCommandHandler;
+  let userInterestFactory: UserInterestFactory;
+  let userRepository: jest.Mocked<IUserRepository>;
+  let interestRepository: jest.Mocked<IInterestRepository>;
+  let userInterestRepository: jest.Mocked<IUserInterestRepository>;
+
+  beforeAll(async () => {
+    advanceTo(new Date());
+
+    const testModule = await Test.createTestingModule({
+      providers: [
+        UpdateUserCommandHandler,
+        UserInterestFactory,
+        { provide: UserRepository, useValue: {} },
+        { provide: InterestRepository, useValue: {} },
+        { provide: UserInterestRepository, useValue: {} },
+      ],
+    }).compile();
+
+    handler = testModule.get(UpdateUserCommandHandler);
+    userInterestFactory = testModule.get(UserInterestFactory);
+    userRepository = testModule.get(UserRepository);
+    interestRepository = testModule.get(InterestRepository);
+    userInterestRepository = testModule.get(UserInterestRepository);
+  });
+
+  afterAll(() => {
+    clear();
+  });
+
+  describe('execute', () => {
+    let user: User;
+    let interests: Interest[];
+    let command: UpdateUserCommand;
+
+    const newUserInterestIds = ['new-user-interest-1', 'new-user-interest-2'];
+
+    const userId = 'userId';
+    const email = 'email@email.com';
+    const phone = null;
+    const homepage = 'https://some.home.page/';
+    const languages = ['some', 'languages'];
+    const interestIds = ['interest1', 'interest2'];
+    const prefer = 'some-prefers';
+
+    beforeEach(() => {
+      user = generateUser({ state: UserState.UNDERGRADUATE });
+      interests = interestIds.map((interestId) =>
+        generateInterest({ id: interestId }),
+      );
+      command = new UpdateUserCommand(
+        userId,
+        email,
+        phone,
+        homepage,
+        languages,
+        interestIds,
+        prefer,
+      );
+
+      userRepository.findById = jest.fn().mockResolvedValue(user);
+      interestRepository.findByIds = jest.fn().mockResolvedValue(interests);
+      userInterestRepository.nextId = jest
+        .fn()
+        .mockReturnValueOnce(newUserInterestIds[0])
+        .mockReturnValueOnce(newUserInterestIds[1]);
+
+      jest.spyOn(user, 'setProfile');
+      userRepository.save = jest.fn();
+      userInterestRepository.removeByUserId = jest.fn();
+      userInterestRepository.save = jest.fn();
+    });
+
+    test('주어진 유저 ID에 해당하는 유저가 존재하지 않을 때, 예외를 발생시켜야 한다', async () => {
+      userRepository.findById = jest.fn().mockResolvedValue(null);
+
+      await expect(handler.execute(command)).rejects.toThrowError(
+        Message.USER_NOT_FOUND,
+      );
+    });
+
+    test('주어진 관심 분야가 존재하지 않을 때, 예외를 발생시켜야 한다', async () => {
+      interestRepository.findByIds = jest
+        .fn()
+        .mockResolvedValue([interests[0]]);
+
+      await expect(handler.execute(command)).rejects.toThrowError(
+        Message.SOME_INTERESTS_NOT_FOUND,
+      );
+    });
+
+    test('유저의 프로필 정보를 의도대로 수정해야 한다', async () => {
+      await handler.execute(command);
+
+      expect(user.setProfile).toBeCalledTimes(1);
+      expect(user.setProfile).toBeCalledWith({
+        email,
+        phone,
+        homepage,
+        languages,
+        prefer,
+      });
+    });
+
+    describe('관심 분야 수정', () => {
+      test('기존에 설정되어 있는 유저의 관심 분야를 모두 삭제해야 한다', async () => {
+        await handler.execute(command);
+
+        expect(userInterestRepository.removeByUserId).toBeCalledTimes(1);
+        expect(userInterestRepository.removeByUserId).toBeCalledWith(userId);
+      });
+
+      test('유저의 새로운 관심 분야를 모두 등록해야 한다', async () => {
+        await handler.execute(command);
+
+        const expected = Array.from({ length: interestIds.length }, (_, idx) =>
+          userInterestFactory.create({
+            id: newUserInterestIds[idx],
+            interestId: interestIds[idx],
+            userId,
+          }),
+        );
+
+        expect(userInterestRepository.save).toBeCalledTimes(1);
+        expect(userInterestRepository.save).toBeCalledWith(...expected);
+      });
+    });
+
+    test('수정한 유저를 저장해야 한다', async () => {
+      await handler.execute(command);
+
+      expect(userRepository.save).toBeCalledTimes(1);
+      expect(userRepository.save).toBeCalledWith(user);
+    });
+
+    test('수정한 유저를 반환해야 한다', async () => {
+      const commandResult = await handler.execute(command);
+
+      expect(commandResult).toEqual(new UpdateUserCommandResult(user));
+    });
+  });
+});

--- a/src/app/application/user/command/updateUser/UpdateUserCommandHandler.ts
+++ b/src/app/application/user/command/updateUser/UpdateUserCommandHandler.ts
@@ -1,0 +1,79 @@
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { ICommandHandler } from '@nestjs/cqrs';
+
+import { Message } from '@sight/constant/message';
+
+import { UpdateUserCommand } from '@sight/app/application/user/command/updateUser/UpdateUserCommand';
+import { UpdateUserCommandResult } from '@sight/app/application/user/command/updateUser/UpdateUserCommandResult';
+
+import { UserInterest } from '@sight/app/domain/interest/model/UserInterest';
+import { UserInterestFactory } from '@sight/app/domain/interest/UserInterestFactory';
+import {
+  IInterestRepository,
+  InterestRepository,
+} from '@sight/app/domain/interest/IInterestRepository';
+import {
+  IUserInterestRepository,
+  UserInterestRepository,
+} from '@sight/app/domain/interest/IUserInterestRepository';
+import {
+  IUserRepository,
+  UserRepository,
+} from '@sight/app/domain/user/IUserRepository';
+
+@Injectable()
+export class UpdateUserCommandHandler
+  implements ICommandHandler<UpdateUserCommand, UpdateUserCommandResult>
+{
+  constructor(
+    @Inject(UserInterestFactory)
+    private readonly userInterestFactory: UserInterestFactory,
+    @Inject(UserRepository)
+    private readonly userRepository: IUserRepository,
+    @Inject(InterestRepository)
+    private readonly interestRepository: IInterestRepository,
+    @Inject(UserInterestRepository)
+    private readonly userInterestRepository: IUserInterestRepository,
+  ) {}
+
+  // TODO @Transactional()
+  async execute(command: UpdateUserCommand): Promise<UpdateUserCommandResult> {
+    const { userId, email, phone, homepage, languages, interestIds, prefer } =
+      command;
+
+    const user = await this.userRepository.findById(userId);
+    if (!user) {
+      throw new NotFoundException(Message.USER_NOT_FOUND);
+    }
+
+    user.setProfile({ email, phone, homepage, languages, prefer });
+    await this.updateInterests(userId, interestIds);
+
+    await this.userRepository.save(user);
+
+    return new UpdateUserCommandResult(user);
+  }
+
+  private async updateInterests(
+    userId: string,
+    interestIds: string[],
+  ): Promise<void> {
+    const interests = await this.interestRepository.findByIds(interestIds);
+    if (interestIds.length !== interests.length) {
+      throw new NotFoundException(Message.SOME_INTERESTS_NOT_FOUND);
+    }
+
+    await this.userInterestRepository.removeByUserId(userId);
+
+    const newUserInterests: UserInterest[] = interestIds.map((interestId) => {
+      const newUserInterest = this.userInterestFactory.create({
+        id: this.userInterestRepository.nextId(),
+        userId,
+        interestId,
+      });
+      return newUserInterest;
+    });
+
+    await this.userInterestRepository.save(...newUserInterests);
+  }
+}

--- a/src/app/application/user/command/updateUser/UpdateUserCommandResult.ts
+++ b/src/app/application/user/command/updateUser/UpdateUserCommandResult.ts
@@ -1,0 +1,5 @@
+import { User } from '@sight/app/domain/user/model/User';
+
+export class UpdateUserCommandResult {
+  constructor(readonly user: User) {}
+}

--- a/src/app/application/user/query/view/UserView.ts
+++ b/src/app/application/user/query/view/UserView.ts
@@ -8,12 +8,12 @@ export interface ProfileView {
   email: string | null;
   phone: string | null;
   homepage: string | null;
-  language: string | null;
+  languages: string[] | null;
   prefer: string | null;
 }
 
 export interface UserView {
-  id: number;
+  id: string;
   name: string;
   password: string | null;
   profile: ProfileView;

--- a/src/app/domain/interest/IInterestRepository.ts
+++ b/src/app/domain/interest/IInterestRepository.ts
@@ -1,0 +1,8 @@
+import { IGenericRepository } from '@sight/core/persistence/IGenericRepository';
+import { Interest } from './model/Interest';
+
+export const InterestRepository = Symbol('InterestRepository');
+
+export interface IInterestRepository extends IGenericRepository<Interest> {
+  findByIds: (interestIds: string[]) => Promise<Interest[]>;
+}

--- a/src/app/domain/interest/IUserInterestRepository.ts
+++ b/src/app/domain/interest/IUserInterestRepository.ts
@@ -1,0 +1,11 @@
+import { IGenericRepository } from '@sight/core/persistence/IGenericRepository';
+
+import { UserInterest } from '@sight/app/domain/interest/model/UserInterest';
+
+export const UserInterestRepository = Symbol('UserInterestRepository');
+
+export interface IUserInterestRepository
+  extends IGenericRepository<UserInterest> {
+  getInterestsByUserId: (userId: string) => Promise<UserInterest>;
+  removeByUserId: (userId: string) => Promise<void>;
+}

--- a/src/app/domain/interest/UserInterestFactory.spec.ts
+++ b/src/app/domain/interest/UserInterestFactory.spec.ts
@@ -1,0 +1,69 @@
+import { advanceTo, clear } from 'jest-date-mock';
+import { Test } from '@nestjs/testing';
+
+import { UserInterestFactory } from './UserInterestFactory';
+import { UserInterest } from './model/UserInterest';
+
+describe('UserInterestFactory', () => {
+  let userInterestFactory: UserInterestFactory;
+
+  const now = new Date();
+
+  const userInterestId = 'userInterestId';
+  const userId = 'userId';
+  const interestId = 'interestId';
+  const createdAt = now;
+
+  beforeAll(async () => {
+    advanceTo(now);
+
+    const testModule = await Test.createTestingModule({
+      providers: [UserInterestFactory],
+    }).compile();
+
+    userInterestFactory = testModule.get(UserInterestFactory);
+  });
+
+  afterAll(() => {
+    clear();
+  });
+
+  describe('create', () => {
+    test('의도대로 유저 관심 분야를 생성해야 한다', () => {
+      const expected = new UserInterest({
+        id: userInterestId,
+        userId,
+        interestId,
+        createdAt: now,
+      });
+
+      const result = userInterestFactory.create({
+        id: userInterestId,
+        userId,
+        interestId,
+      });
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('reconstitute', () => {
+    test('의도대로 유저 관심 분야를 재구성해야 한다', () => {
+      const expected = new UserInterest({
+        id: userInterestId,
+        userId,
+        interestId,
+        createdAt,
+      });
+
+      const result = userInterestFactory.reconstitute({
+        id: userInterestId,
+        userId,
+        interestId,
+        createdAt,
+      });
+
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/src/app/domain/interest/UserInterestFactory.ts
+++ b/src/app/domain/interest/UserInterestFactory.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+
+import {
+  UserInterest,
+  UserInterestConstructorParams,
+} from '@sight/app/domain/interest/model/UserInterest';
+
+type UserInterestCreateParams = Omit<
+  UserInterestConstructorParams,
+  'createdAt'
+>;
+type UserInterestReconstituteParams = UserInterestConstructorParams;
+
+@Injectable()
+export class UserInterestFactory {
+  create(params: UserInterestCreateParams): UserInterest {
+    const now = new Date();
+    return new UserInterest({ ...params, createdAt: now });
+  }
+
+  reconstitute(params: UserInterestReconstituteParams): UserInterest {
+    return new UserInterest(params);
+  }
+}

--- a/src/app/domain/interest/model/Interest.ts
+++ b/src/app/domain/interest/model/Interest.ts
@@ -1,24 +1,27 @@
+import { AggregateRoot } from '@nestjs/cqrs';
+
 export type InterestConstructorParams = {
-  id: number;
+  id: string;
   name: string;
   description: string;
   createdAt: Date;
 };
 
-export class Interest {
-  private _id: number;
+export class Interest extends AggregateRoot {
+  private _id: string;
   private _name: string;
   private _description: string;
   private _createdAt: Date;
 
   constructor(params: InterestConstructorParams) {
+    super();
     this._id = params.id;
     this._name = params.name;
     this._description = params.description;
     this._createdAt = params.createdAt;
   }
 
-  get id(): number {
+  get id(): string {
     return this._id;
   }
 

--- a/src/app/domain/interest/model/UserInterest.ts
+++ b/src/app/domain/interest/model/UserInterest.ts
@@ -1,0 +1,39 @@
+import { AggregateRoot } from '@nestjs/cqrs';
+
+export type UserInterestConstructorParams = {
+  id: string;
+  userId: string;
+  interestId: string;
+  createdAt: Date;
+};
+
+export class UserInterest extends AggregateRoot {
+  private _id: string;
+  private _userId: string;
+  private _interestId: string;
+  private _createdAt: Date;
+
+  constructor(params: UserInterestConstructorParams) {
+    super();
+    this._id = params.id;
+    this._userId = params.userId;
+    this._interestId = params.interestId;
+    this._createdAt = params.createdAt;
+  }
+
+  get id(): string {
+    return this._id;
+  }
+
+  get userId(): string {
+    return this._userId;
+  }
+
+  get interestId(): string {
+    return this._interestId;
+  }
+
+  get createdAt(): Date {
+    return this._createdAt;
+  }
+}

--- a/src/app/domain/user/IUserRepository.ts
+++ b/src/app/domain/user/IUserRepository.ts
@@ -1,0 +1,6 @@
+import { IGenericRepository } from '@sight/core/persistence/IGenericRepository';
+import { User } from './model/User';
+
+export const UserRepository = Symbol('UserRepository');
+
+export interface IUserRepository extends IGenericRepository<User> {}

--- a/src/app/domain/user/model/Profile.ts
+++ b/src/app/domain/user/model/Profile.ts
@@ -1,3 +1,5 @@
+import { ValueObject } from '@sight/core/ddd/ValueObject';
+
 export type ProfileConstructorParams = {
   name: string;
   college: string;
@@ -6,66 +8,31 @@ export type ProfileConstructorParams = {
   email: string | null;
   phone: string | null;
   homepage: string | null;
-  language: string | null;
+  languages: string[] | null;
   prefer: string | null;
 };
 
-export class Profile {
-  private _name: string;
-  private _college: string;
-  private _grade: number;
-  private _number: number | null;
-  private _email: string | null;
-  private _phone: string | null;
-  private _homepage: string | null;
-  private _language: string | null;
-  private _prefer: string | null;
+export class Profile extends ValueObject {
+  readonly name: string;
+  readonly college: string;
+  readonly grade: number;
+  readonly number: number | null;
+  readonly email: string | null;
+  readonly phone: string | null;
+  readonly homepage: string | null;
+  readonly languages: string[] | null;
+  readonly prefer: string | null;
 
   constructor(params: ProfileConstructorParams) {
-    this._name = params.name;
-    this._college = params.college;
-    this._grade = params.grade;
-    this._number = params.number;
-    this._email = params.email;
-    this._phone = params.phone;
-    this._homepage = params.homepage;
-    this._language = params.language;
-    this._prefer = params.prefer;
-  }
-
-  get name(): string {
-    return this._name;
-  }
-
-  get college(): string {
-    return this._college;
-  }
-
-  get grade(): number {
-    return this._grade;
-  }
-
-  get number(): number | null {
-    return this._number;
-  }
-
-  get email(): string | null {
-    return this._email;
-  }
-
-  get phone(): string | null {
-    return this._phone;
-  }
-
-  get homepage(): string | null {
-    return this._homepage;
-  }
-
-  get language(): string | null {
-    return this._language;
-  }
-
-  get prefer(): string | null {
-    return this._prefer;
+    super();
+    this.name = params.name;
+    this.college = params.college;
+    this.grade = params.grade;
+    this.number = params.number;
+    this.email = params.email;
+    this.phone = params.phone;
+    this.homepage = params.homepage;
+    this.languages = params.languages;
+    this.prefer = params.prefer;
   }
 }

--- a/src/app/domain/user/model/User.spec.ts
+++ b/src/app/domain/user/model/User.spec.ts
@@ -1,20 +1,28 @@
-import { testNow } from '@sight/__test__/constant';
 import { DomainFixture } from '@sight/__test__/fixtures';
 
 import { User } from '@sight/app/domain/user/model/User';
+import { advanceTo, clear } from 'jest-date-mock';
 
 describe('User', () => {
   let user: User;
 
+  const now = new Date();
+
   beforeEach(() => {
+    advanceTo(now);
+
     user = DomainFixture.generateUser();
+  });
+
+  afterAll(() => {
+    clear();
   });
 
   describe('login', () => {
     test('로그인 할 때, lastLoginAt의 값이 지금 시각으로 변경되어야 한다', () => {
       user.login();
 
-      expect(user.lastLoginAt).toEqual(testNow);
+      expect(user.lastLoginAt).toEqual(now);
     });
   });
 });

--- a/src/constant/message.ts
+++ b/src/constant/message.ts
@@ -1,0 +1,8 @@
+export const Message = {
+  // 404 Not Found
+  USER_NOT_FOUND: 'User not found',
+  SOME_INTERESTS_NOT_FOUND: 'Some interests not found',
+
+  // 422 Unprocessable Entity
+  GRADUATED_USER_ONLY_CAN_CHANGE_EMAIL: 'Graduated user only can change email',
+};

--- a/src/core/ddd/ValueObject.ts
+++ b/src/core/ddd/ValueObject.ts
@@ -1,0 +1,1 @@
+export abstract class ValueObject {}

--- a/src/core/persistence/IGenericRepository.ts
+++ b/src/core/persistence/IGenericRepository.ts
@@ -1,0 +1,11 @@
+import { AggregateRoot } from '@nestjs/cqrs';
+
+export interface IGenericRepository<
+  T extends AggregateRoot,
+  TIdentity = string,
+> {
+  nextId: () => TIdentity;
+  findById: (id: TIdentity) => Promise<T | null>;
+  save: (...domain: T[]) => Promise<void>;
+  remove: (...domain: T[]) => Promise<void>;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "strict": true,
+    "strictNullChecks": true,
     "declaration": true,
     "removeComments": true,
     "emitDecoratorMetadata": true,
@@ -17,7 +18,6 @@
     },
     "incremental": true,
     "skipLibCheck": true,
-    "strictNullChecks": false,
     "noImplicitAny": false,
     "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": false,


### PR DESCRIPTION
### 주요 변경 사항
<!-- 해당 PR로 변경되는 사항을 한 눈에 알기 쉽게 정리해주세요. -->

유저 정보 수정 커맨드 핸들러를 구현하였습니다.

이를 구현하기 위해, 아래와 같은 작업을 하였습니다.
- 유저와 관심 분야 간 연결을 위한 `UserInterest` 모델 구현
- `UserInterest` 모델과 `Interest`, 그리고 `User`에 대한 Repository 인터페이스 추가
- `UserInterest`에 대한 팩토리 구현

또, Repository의 공통 기능을 정의하기 위해 아래와 같은 작업을 하였습니다.

- `IGenericRepository` 구현

마지막으로, 관련 테스트를 추가하였습니다.

### 변경 이유
<!-- 변경이 일어나는 이유를 한 눈에 알기 쉽게 정리해주세요. -->

- 레거시 기능을 구현합니다.
- 이 과정에서 Repository가 필요하였기에 같이 구현하였습니다.
- Fixes: #9 
