### PR TITLE
fix: 유저 정보 변경 시 슬랙 메시지를 전송하도록 수정

### DIFF
--- a/src/app/application/user/command/updateUser/UpdateUserCommandHandler.ts
+++ b/src/app/application/user/command/updateUser/UpdateUserCommandHandler.ts
@@ -20,6 +20,11 @@ import {
   IUserRepository,
   UserRepository,
 } from '@sight/app/domain/user/IUserRepository';
+import {
+  ISlackSender,
+  SlackSender,
+} from '@sight/app/domain/adapter/ISlackSender';
+import { SlackMessageCategory } from '@sight/app/domain/message/model/constant';
 
 @Injectable()
 export class UpdateUserCommandHandler
@@ -34,6 +39,8 @@ export class UpdateUserCommandHandler
     private readonly interestRepository: IInterestRepository,
     @Inject(UserInterestRepository)
     private readonly userInterestRepository: IUserInterestRepository,
+    @Inject(SlackSender)
+    private readonly slackSender: ISlackSender,
   ) {}
 
   // TODO @Transactional()
@@ -50,6 +57,12 @@ export class UpdateUserCommandHandler
     await this.updateInterests(userId, interestIds);
 
     await this.userRepository.save(user);
+    await this.slackSender.send({
+      sourceUserId: null,
+      targetUserId: userId,
+      message: '회원 정보를 수정했습니다.',
+      category: SlackMessageCategory.USER_DATA,
+    });
 
     return new UpdateUserCommandResult(user);
   }

--- a/src/app/domain/adapter/ISlackSender.ts
+++ b/src/app/domain/adapter/ISlackSender.ts
@@ -14,6 +14,8 @@ export type SlackBroadcastParams = Omit<
   'sourceUserId' | 'targetUserId'
 >;
 
+export const SlackSender = Symbol('SlackSender');
+
 export interface ISlackSender {
   send: (params: SlackSendParams) => Promise<void>;
   sendToManagers: (params: SlackSendToManagersParams) => Promise<void>;


### PR DESCRIPTION
### 주요 변경 사항
<!-- 해당 PR로 변경되는 사항을 한 눈에 알기 쉽게 정리해주세요. -->

유저 정보 변경 시 슬랙 메시지를 전송하도록 수정합니다.

### 변경 이유
<!-- 변경이 일어나는 이유를 한 눈에 알기 쉽게 정리해주세요. -->

유저 정보가 변경되면 기존에는 슬랙 메시지가 전송되었습니다.
