### PR TITLE
feat: 교류 회원 정보 수정 핸들러 구현 및 이벤트 핸들러 구현

### DIFF
--- a/src/app/application/interest/query/listInterest/ListInterestQueryHandler.spec.ts
+++ b/src/app/application/interest/query/listInterest/ListInterestQueryHandler.spec.ts
@@ -1,11 +1,11 @@
 import { Test } from '@nestjs/testing';
 
-import { ViewFixture } from '@sight/__test__/fixtures';
-
 import { IInterestQuery } from '@sight/app/application/interest/query/IInterestQuery';
 import { ListInterestQueryHandler } from '@sight/app/application/interest/query/listInterest/ListInterestQueryHandler';
 import { ListInterestQueryResult } from '@sight/app/application/interest/query/listInterest/ListInterestQueryResult';
 import { InterestListView } from '@sight/app/application/interest/query/view/InterestListView';
+
+import { ViewFixture } from '@sight/__test__/fixtures';
 
 describe('ListInterestQueryHandler', () => {
   let listInterestQueryHandler: ListInterestQueryHandler;

--- a/src/app/application/user/command/updateUnitedUser/UpdateUnitedUserComandHandler.spec.ts
+++ b/src/app/application/user/command/updateUnitedUser/UpdateUnitedUserComandHandler.spec.ts
@@ -1,16 +1,18 @@
 import { Test } from '@nestjs/testing';
 import { advanceTo, clear } from 'jest-date-mock';
 
-import { UpdateUnitedUserCommandHandler } from './UpdateUnitedUserCommandHandler';
+import { UpdateUnitedUserCommand } from '@sight/app/application/user/command/updateUnitedUser/UpdateUnitedUserCommand';
+import { UpdateUnitedUserCommandHandler } from '@sight/app/application/user/command/updateUnitedUser/UpdateUnitedUserCommandHandler';
+
+import { UserState } from '@sight/app/domain/user/model/constant';
+import { User } from '@sight/app/domain/user/model/User';
 import {
   IUserRepository,
   UserRepository,
 } from '@sight/app/domain/user/IUserRepository';
-import { User } from '@sight/app/domain/user/model/User';
+
 import { generateUser } from '@sight/__test__/fixtures/domain';
-import { UserState } from '@sight/app/domain/user/model/constant';
 import { Message } from '@sight/constant/message';
-import { UpdateUnitedUserCommand } from './UpdateUnitedUserCommand';
 
 describe('UpdateUnitedUserCommandHandler', () => {
   let handler: UpdateUnitedUserCommandHandler;

--- a/src/app/application/user/command/updateUnitedUser/UpdateUnitedUserComandHandler.spec.ts
+++ b/src/app/application/user/command/updateUnitedUser/UpdateUnitedUserComandHandler.spec.ts
@@ -1,0 +1,74 @@
+import { Test } from '@nestjs/testing';
+import { advanceTo, clear } from 'jest-date-mock';
+
+import { UpdateUnitedUserCommandHandler } from './UpdateUnitedUserCommandHandler';
+import {
+  IUserRepository,
+  UserRepository,
+} from '@sight/app/domain/user/IUserRepository';
+import { User } from '@sight/app/domain/user/model/User';
+import { generateUser } from '@sight/__test__/fixtures/domain';
+import { UserState } from '@sight/app/domain/user/model/constant';
+import { Message } from '@sight/constant/message';
+import { UpdateUnitedUserCommand } from './UpdateUnitedUserCommand';
+
+describe('UpdateUnitedUserCommandHandler', () => {
+  let handler: UpdateUnitedUserCommandHandler;
+  let userRepository: jest.Mocked<IUserRepository>;
+
+  beforeAll(async () => {
+    advanceTo(new Date());
+
+    const testModule = await Test.createTestingModule({
+      providers: [
+        UpdateUnitedUserCommandHandler,
+        { provide: UserRepository, useValue: {} },
+      ],
+    }).compile();
+
+    handler = testModule.get(UpdateUnitedUserCommandHandler);
+    userRepository = testModule.get(UserRepository);
+  });
+
+  afterAll(() => {
+    clear();
+  });
+
+  describe('execute', () => {
+    let user: User;
+    let command: UpdateUnitedUserCommand;
+
+    const userId = 'userId';
+    const newEmail = 'new-email@email.com';
+
+    beforeEach(() => {
+      user = generateUser({ id: userId, state: UserState.UNITED });
+      command = new UpdateUnitedUserCommand(userId, newEmail);
+
+      userRepository.findById = jest.fn().mockResolvedValue(user);
+
+      userRepository.save = jest.fn();
+    });
+
+    test('교류 유저가 존재하지 않으면 예외를 발생시켜야 한다', async () => {
+      userRepository.findById = jest.fn().mockResolvedValue(null);
+
+      await expect(handler.execute(command)).rejects.toThrowError(
+        Message.USER_NOT_FOUND,
+      );
+    });
+
+    test('교류 유저의 이메일을 수정해야 한다', async () => {
+      await handler.execute(command);
+
+      expect(user.profile.email).toEqual(newEmail);
+    });
+
+    test('변경된 유저의 정보를 저장해야 한다', async () => {
+      await handler.execute(command);
+
+      expect(userRepository.save).toBeCalledWith(user);
+      expect(userRepository.save).toBeCalledTimes(1);
+    });
+  });
+});

--- a/src/app/application/user/command/updateUnitedUser/UpdateUnitedUserCommand.ts
+++ b/src/app/application/user/command/updateUnitedUser/UpdateUnitedUserCommand.ts
@@ -1,0 +1,8 @@
+import { ICommand } from '@nestjs/cqrs';
+
+export class UpdateUnitedUserCommand implements ICommand {
+  constructor(
+    readonly userId: string,
+    readonly email: string,
+  ) {}
+}

--- a/src/app/application/user/command/updateUnitedUser/UpdateUnitedUserCommandHandler.ts
+++ b/src/app/application/user/command/updateUnitedUser/UpdateUnitedUserCommandHandler.ts
@@ -1,0 +1,40 @@
+import { Inject, NotFoundException } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+
+import { UpdateUnitedUserCommand } from '@sight/app/application/user/command/updateUnitedUser/UpdateUnitedUserCommand';
+import { UpdateUnitedUserCommandResult } from '@sight/app/application/user/command/updateUnitedUser/UpdateUnitedUserCommandResult';
+
+import {
+  IUserRepository,
+  UserRepository,
+} from '@sight/app/domain/user/IUserRepository';
+
+import { Message } from '@sight/constant/message';
+
+@CommandHandler(UpdateUnitedUserCommand)
+export class UpdateUnitedUserCommandHandler
+  implements
+    ICommandHandler<UpdateUnitedUserCommand, UpdateUnitedUserCommandResult>
+{
+  constructor(
+    @Inject(UserRepository)
+    private readonly userRepository: IUserRepository,
+  ) {}
+
+  // TODO @Transactional
+  async execute(
+    command: UpdateUnitedUserCommand,
+  ): Promise<UpdateUnitedUserCommandResult> {
+    const { userId, email } = command;
+
+    const user = await this.userRepository.findById(userId);
+    if (!user) {
+      throw new NotFoundException(Message.USER_NOT_FOUND);
+    }
+
+    user.setProfile({ email });
+    await this.userRepository.save(user);
+
+    return new UpdateUnitedUserCommandResult(user);
+  }
+}

--- a/src/app/application/user/command/updateUnitedUser/UpdateUnitedUserCommandResult.ts
+++ b/src/app/application/user/command/updateUnitedUser/UpdateUnitedUserCommandResult.ts
@@ -1,0 +1,5 @@
+import { User } from '@sight/app/domain/user/model/User';
+
+export class UpdateUnitedUserCommandResult {
+  constructor(readonly user: User) {}
+}

--- a/src/app/application/user/command/updateUser/UpdateUserCommandHandler.spec.ts
+++ b/src/app/application/user/command/updateUser/UpdateUserCommandHandler.spec.ts
@@ -172,12 +172,6 @@ describe('UpdateUserCommandHandler', () => {
       expect(userRepository.save).toBeCalledWith(user);
     });
 
-    test('요청자에게 슬랙 메시지를 보내야 한다', async () => {
-      await handler.execute(command);
-
-      expect(slackSender.send).toBeCalledTimes(1);
-    });
-
     test('수정한 유저를 반환해야 한다', async () => {
       const commandResult = await handler.execute(command);
 

--- a/src/app/application/user/command/updateUser/UpdateUserCommandHandler.spec.ts
+++ b/src/app/application/user/command/updateUser/UpdateUserCommandHandler.spec.ts
@@ -1,19 +1,18 @@
 import { Test } from '@nestjs/testing';
 import { advanceTo, clear } from 'jest-date-mock';
 
-import { Message } from '@sight/constant/message';
-import {
-  generateInterest,
-  generateUser,
-} from '@sight/__test__/fixtures/domain';
-
 import { UpdateUserCommand } from '@sight/app/application/user/command/updateUser/UpdateUserCommand';
 import { UpdateUserCommandHandler } from '@sight/app/application/user/command/updateUser/UpdateUserCommandHandler';
 import { UpdateUserCommandResult } from '@sight/app/application/user/command/updateUser/UpdateUserCommandResult';
 
 import { Interest } from '@sight/app/domain/interest/model/Interest';
 import { UserInterestFactory } from '@sight/app/domain/interest/UserInterestFactory';
+import { UserState } from '@sight/app/domain/user/model/constant';
 import { User } from '@sight/app/domain/user/model/User';
+import {
+  ISlackSender,
+  SlackSender,
+} from '@sight/app/domain/adapter/ISlackSender';
 import {
   IInterestRepository,
   InterestRepository,
@@ -26,11 +25,12 @@ import {
   IUserRepository,
   UserRepository,
 } from '@sight/app/domain/user/IUserRepository';
-import { UserState } from '@sight/app/domain/user/model/constant';
+
+import { Message } from '@sight/constant/message';
 import {
-  ISlackSender,
-  SlackSender,
-} from '@sight/app/domain/adapter/ISlackSender';
+  generateInterest,
+  generateUser,
+} from '@sight/__test__/fixtures/domain';
 
 describe('UpdateUserCommandHandler', () => {
   let handler: UpdateUserCommandHandler;

--- a/src/app/application/user/command/updateUser/UpdateUserCommandHandler.ts
+++ b/src/app/application/user/command/updateUser/UpdateUserCommandHandler.ts
@@ -1,8 +1,6 @@
 import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { ICommandHandler } from '@nestjs/cqrs';
 
-import { Message } from '@sight/constant/message';
-
 import { UpdateUserCommand } from '@sight/app/application/user/command/updateUser/UpdateUserCommand';
 import { UpdateUserCommandResult } from '@sight/app/application/user/command/updateUser/UpdateUserCommandResult';
 
@@ -20,11 +18,8 @@ import {
   IUserRepository,
   UserRepository,
 } from '@sight/app/domain/user/IUserRepository';
-import {
-  ISlackSender,
-  SlackSender,
-} from '@sight/app/domain/adapter/ISlackSender';
-import { SlackMessageCategory } from '@sight/app/domain/message/model/constant';
+
+import { Message } from '@sight/constant/message';
 
 @Injectable()
 export class UpdateUserCommandHandler
@@ -39,8 +34,6 @@ export class UpdateUserCommandHandler
     private readonly interestRepository: IInterestRepository,
     @Inject(UserInterestRepository)
     private readonly userInterestRepository: IUserInterestRepository,
-    @Inject(SlackSender)
-    private readonly slackSender: ISlackSender,
   ) {}
 
   // TODO @Transactional()
@@ -57,12 +50,6 @@ export class UpdateUserCommandHandler
     await this.updateInterests(userId, interestIds);
 
     await this.userRepository.save(user);
-    await this.slackSender.send({
-      sourceUserId: null,
-      targetUserId: userId,
-      message: '회원 정보를 수정했습니다.',
-      category: SlackMessageCategory.USER_DATA,
-    });
 
     return new UpdateUserCommandResult(user);
   }

--- a/src/app/application/user/eventHandler/UserProfileUpdatedHandler.spec.ts
+++ b/src/app/application/user/eventHandler/UserProfileUpdatedHandler.spec.ts
@@ -1,0 +1,57 @@
+import { Test } from '@nestjs/testing';
+import { advanceTo, clear } from 'jest-date-mock';
+
+import { UserProfileUpdatedHandler } from '@sight/app/application/user/eventHandler/UserProfileUpdatedHandler';
+
+import { UserProfileUpdated } from '@sight/app/domain/user/event/UserProfileUpdated';
+import { User } from '@sight/app/domain/user/model/User';
+import {
+  ISlackSender,
+  SlackSender,
+} from '@sight/app/domain/adapter/ISlackSender';
+
+import { generateUser } from '@sight/__test__/fixtures/domain';
+
+describe('UserProfileUpdatedHandler', () => {
+  let handler: UserProfileUpdatedHandler;
+  let slackSender: jest.Mocked<ISlackSender>;
+
+  beforeAll(async () => {
+    advanceTo(new Date());
+
+    const testModule = await Test.createTestingModule({
+      providers: [
+        UserProfileUpdatedHandler,
+        { provide: SlackSender, useValue: {} },
+      ],
+    }).compile();
+
+    handler = testModule.get(UserProfileUpdatedHandler);
+    slackSender = testModule.get(SlackSender);
+  });
+
+  afterAll(() => {
+    clear();
+  });
+
+  describe('handle', () => {
+    let user: User;
+    let event: UserProfileUpdated;
+
+    beforeEach(() => {
+      user = generateUser();
+      event = new UserProfileUpdated(user);
+
+      slackSender.send = jest.fn();
+    });
+
+    test('유저 자신에게 슬랙 메시지를 보내야 한다', () => {
+      handler.handle(event);
+
+      expect(slackSender.send).toBeCalledTimes(1);
+      expect(slackSender.send).toBeCalledWith(
+        expect.objectContaining({ targetUserId: user.id }),
+      );
+    });
+  });
+});

--- a/src/app/application/user/eventHandler/UserProfileUpdatedHandler.ts
+++ b/src/app/application/user/eventHandler/UserProfileUpdatedHandler.ts
@@ -1,0 +1,30 @@
+import { Inject } from '@nestjs/common';
+import { EventsHandler, IEventHandler } from '@nestjs/cqrs';
+
+import { UserProfileUpdated } from '@sight/app/domain/user/event/UserProfileUpdated';
+import {
+  ISlackSender,
+  SlackSender,
+} from '@sight/app/domain/adapter/ISlackSender';
+import { SlackMessageCategory } from '@sight/app/domain/message/model/constant';
+
+@EventsHandler(UserProfileUpdated)
+export class UserProfileUpdatedHandler
+  implements IEventHandler<UserProfileUpdated>
+{
+  constructor(
+    @Inject(SlackSender)
+    private readonly slackSender: ISlackSender,
+  ) {}
+
+  handle(event: UserProfileUpdated) {
+    const { user } = event;
+
+    this.slackSender.send({
+      sourceUserId: null,
+      targetUserId: user.id,
+      message: '회원 정보를 수정했습니다.',
+      category: SlackMessageCategory.USER_DATA,
+    });
+  }
+}

--- a/src/app/application/user/eventHandler/UserProfileUpdatedHandler.ts
+++ b/src/app/application/user/eventHandler/UserProfileUpdatedHandler.ts
@@ -1,12 +1,12 @@
 import { Inject } from '@nestjs/common';
 import { EventsHandler, IEventHandler } from '@nestjs/cqrs';
 
+import { SlackMessageCategory } from '@sight/app/domain/message/model/constant';
 import { UserProfileUpdated } from '@sight/app/domain/user/event/UserProfileUpdated';
 import {
   ISlackSender,
   SlackSender,
 } from '@sight/app/domain/adapter/ISlackSender';
-import { SlackMessageCategory } from '@sight/app/domain/message/model/constant';
 
 @EventsHandler(UserProfileUpdated)
 export class UserProfileUpdatedHandler

--- a/src/app/application/user/query/listUser/ListUserQueryHandler.spec.ts
+++ b/src/app/application/user/query/listUser/ListUserQueryHandler.spec.ts
@@ -1,7 +1,5 @@
 import { Test } from '@nestjs/testing';
 
-import { ViewFixture } from '@sight/__test__/fixtures';
-
 import { IUserQuery } from '@sight/app/application/user/query/IUserQuery';
 import { ListUserQuery } from '@sight/app/application/user/query/listUser/ListUserQuery';
 import { ListUserQueryHandler } from '@sight/app/application/user/query/listUser/ListUserQueryHandler';
@@ -9,6 +7,8 @@ import { ListUserQueryResult } from '@sight/app/application/user/query/listUser/
 import { UserListView } from '@sight/app/application/user/query/view/UserListView';
 
 import { UserState } from '@sight/app/domain/user/model/constant';
+
+import { ViewFixture } from '@sight/__test__/fixtures';
 
 describe('ListUserQueryHandler', () => {
   let listUserQueryHandler: ListUserQueryHandler;

--- a/src/app/domain/adapter/ISlackSender.ts
+++ b/src/app/domain/adapter/ISlackSender.ts
@@ -16,8 +16,9 @@ export type SlackBroadcastParams = Omit<
 
 export const SlackSender = Symbol('SlackSender');
 
+// async sender
 export interface ISlackSender {
-  send: (params: SlackSendParams) => Promise<void>;
-  sendToManagers: (params: SlackSendToManagersParams) => Promise<void>;
-  broadcast: (params: SlackBroadcastParams) => Promise<void>;
+  send: (params: SlackSendParams) => void;
+  sendToManagers: (params: SlackSendToManagersParams) => void;
+  broadcast: (params: SlackBroadcastParams) => void;
 }

--- a/src/app/domain/interest/IInterestRepository.ts
+++ b/src/app/domain/interest/IInterestRepository.ts
@@ -1,5 +1,6 @@
 import { IGenericRepository } from '@sight/core/persistence/IGenericRepository';
-import { Interest } from './model/Interest';
+
+import { Interest } from '@sight/app/domain/interest/model/Interest';
 
 export const InterestRepository = Symbol('InterestRepository');
 

--- a/src/app/domain/interest/UserInterestFactory.spec.ts
+++ b/src/app/domain/interest/UserInterestFactory.spec.ts
@@ -1,8 +1,8 @@
-import { advanceTo, clear } from 'jest-date-mock';
 import { Test } from '@nestjs/testing';
+import { advanceTo, clear } from 'jest-date-mock';
 
-import { UserInterestFactory } from './UserInterestFactory';
-import { UserInterest } from './model/UserInterest';
+import { UserInterest } from '@sight/app/domain/interest/model/UserInterest';
+import { UserInterestFactory } from '@sight/app/domain/interest/UserInterestFactory';
 
 describe('UserInterestFactory', () => {
   let userInterestFactory: UserInterestFactory;

--- a/src/app/domain/user/IUserRepository.ts
+++ b/src/app/domain/user/IUserRepository.ts
@@ -1,5 +1,6 @@
 import { IGenericRepository } from '@sight/core/persistence/IGenericRepository';
-import { User } from './model/User';
+
+import { User } from '@sight/app/domain/user/model/User';
 
 export const UserRepository = Symbol('UserRepository');
 

--- a/src/app/domain/user/event/UserProfileUpdated.ts
+++ b/src/app/domain/user/event/UserProfileUpdated.ts
@@ -1,0 +1,5 @@
+import { User } from '@sight/app/domain/user/model/User';
+
+export class UserProfileUpdated {
+  constructor(readonly user: User) {}
+}

--- a/src/app/domain/user/model/User.spec.ts
+++ b/src/app/domain/user/model/User.spec.ts
@@ -13,7 +13,7 @@ describe('User', () => {
   beforeEach(() => {
     advanceTo(now);
 
-    user = DomainFixture.generateUser();
+    user = DomainFixture.generateUser({ state: UserState.UNDERGRADUATE });
   });
 
   afterAll(() => {
@@ -24,6 +24,14 @@ describe('User', () => {
     const email = 'some@email.com';
     const grade = 1;
     const name = '김러리';
+
+    test('교류 회원이 이메일 외에 다른 정보를 변경할 때, 예외를 발생시켜야 한다', () => {
+      user = DomainFixture.generateUser({ state: UserState.UNITED });
+
+      expect(() => user.setProfile({ phone: '010-0000-0000' })).toThrowError(
+        Message.UNITED_USER_CAN_ONLY_CHANGE_EMAIL,
+      );
+    });
 
     test('졸업 상태가 아닌 유저가 전화번호를 변경할 때, 예외를 발생시켜야 한다', () => {
       user = DomainFixture.generateUser({ state: UserState.UNDERGRADUATE });

--- a/src/app/domain/user/model/User.spec.ts
+++ b/src/app/domain/user/model/User.spec.ts
@@ -1,8 +1,9 @@
-import { DomainFixture } from '@sight/__test__/fixtures';
-
-import { User } from '@sight/app/domain/user/model/User';
 import { advanceTo, clear } from 'jest-date-mock';
-import { UserState } from './constant';
+
+import { UserState } from '@sight/app/domain/user/model/constant';
+import { User } from '@sight/app/domain/user/model/User';
+
+import { DomainFixture } from '@sight/__test__/fixtures';
 import { Message } from '@sight/constant/message';
 
 describe('User', () => {

--- a/src/constant/message.ts
+++ b/src/constant/message.ts
@@ -5,4 +5,5 @@ export const Message = {
 
   // 422 Unprocessable Entity
   GRADUATED_USER_ONLY_CAN_CHANGE_EMAIL: 'Graduated user only can change email',
+  UNITED_USER_CAN_ONLY_CHANGE_EMAIL: 'United user can only change email',
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import { NestFactory } from '@nestjs/core';
+
 import { AppModule } from '@sight/app.module';
 
 async function bootstrap() {


### PR DESCRIPTION
### 주요 변경 사항
<!-- 해당 PR로 변경되는 사항을 한 눈에 알기 쉽게 정리해주세요. -->

교류 회원 정보를 수정하는 커맨드 핸들러(`UpdateUnitedUserCommandHandler`)를 구현하고 관련 테스트를 추가하였습니다.

또한, 유저 정보가 변경되었을 때 슬랙 메시지 보내는 부분을 이벤트 핸들러로 옮겼습니다.

### 변경 이유
<!-- 변경이 일어나는 이유를 한 눈에 알기 쉽게 정리해주세요. -->

유저 정보 변경이 발생했을 때, 공통적으로 슬랙 메시지가 전송됩니다. 해당 로직을 이벤트 핸들러로 묶어서 처리하도록 수정합니다.
