### PR TITLE
test: deprecated된 faker 함수 수정

### DIFF
--- a/src/__test__/fixtures/domain.ts
+++ b/src/__test__/fixtures/domain.ts
@@ -19,7 +19,7 @@ export function generateUser(params?: Partial<UserConstructorParams>): User {
       grade: faker.number.int(),
       number: faker.number.int(),
       email: faker.internet.email(),
-      phone: faker.phone.number('###-####-####'),
+      phone: faker.phone.number(),
       homepage: faker.internet.url(),
       languages: [faker.lorem.word()],
       prefer: faker.lorem.word(),

--- a/src/__test__/fixtures/view.ts
+++ b/src/__test__/fixtures/view.ts
@@ -18,7 +18,7 @@ export function generateUserView(params?: Partial<UserView>): UserView {
       grade: faker.number.int(),
       number: faker.number.int(),
       email: faker.internet.email(),
-      phone: faker.phone.number('###-####-####'),
+      phone: faker.phone.number(),
       homepage: faker.internet.url(),
       languages: [faker.lorem.word()],
       prefer: faker.lorem.word(),


### PR DESCRIPTION
### 주요 변경 사항
<!-- 해당 PR로 변경되는 사항을 한 눈에 알기 쉽게 정리해주세요. -->

`faker.phone.number(format: string)`이 deprecated되어, 이를 수정합니다.

### 변경 이유
<!-- 변경이 일어나는 이유를 한 눈에 알기 쉽게 정리해주세요. -->

해당 함수가 deprecate되어서.
