### PR TITLE
build: 도커 관련 파일 생성

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.gitignore
+.dockerignore
+
+dist
+node_modules
+coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:18.18.0-alpine as builder
+
+ENV NODE_ENV build
+WORKDIR /sight
+
+COPY ./ /sight
+
+RUN npm ci
+RUN npm run build \
+  && npm prune --production
+
+FROM node:18.18.0-alpine
+
+ENV NODE_ENV production
+WORKDIR /sight
+
+COPY --from=builder /sight/package*.json ./
+COPY --from=builder /sight/node_modules/ ./node_modules/
+COPY --from=builder /sight/dist/ ./dist/
+
+EXPOSE 3000
+CMD ["npm", "run", "start:prod"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,7 @@
+services:
+  sight:
+    build:
+      context: .
+    restart: always
+    ports:
+      - "3000:3000"

--- a/src/core/persistence/transaction/Transactional.spec.ts
+++ b/src/core/persistence/transaction/Transactional.spec.ts
@@ -81,7 +81,7 @@ describe('Transactional', () => {
 
             const newEntity = new MockEntity();
             newEntity.id = newMockEntityId;
-            managerInTransaction.insert(newEntity);
+            await managerInTransaction.insert(newEntity);
 
             throw new Error();
           });


### PR DESCRIPTION
### 주요 변경 사항
<!-- 해당 PR로 변경되는 사항을 한 눈에 알기 쉽게 정리해주세요. -->

도커 관련 파일을 생성합니다.

### 변경 이유
<!-- 변경이 일어나는 이유를 한 눈에 알기 쉽게 정리해주세요. -->

이후에 mysql 등 DB도 같이 사용해야 하는데, 로컬에서 개발할 때 따로 mysql을 띄우면 불편함이 있습니다.
따라서 미리 docker compose 파일을 정의합니다.

또, 배포 시에 ECS를 활용할 예정이기 때문에 컨테이너화 하는 목적도 있습니다.