### PR TITLE
fix: 관심사의 id로 쿼리하도록 수정

### DIFF
--- a/src/app/application/user/query/IUserQuery.ts
+++ b/src/app/application/user/query/IUserQuery.ts
@@ -4,7 +4,7 @@ import { UserState } from '@sight/app/domain/user/model/constant';
 
 export type ListUserParams = {
   state: UserState | null;
-  interest: string | null;
+  interestId: string | null;
   limit: number;
   offset: number;
 };

--- a/src/app/application/user/query/listUser/ListUserQuery.ts
+++ b/src/app/application/user/query/listUser/ListUserQuery.ts
@@ -5,7 +5,7 @@ import { UserState } from '@sight/app/domain/user/model/constant';
 export class ListUserQuery implements IQuery {
   constructor(
     readonly state: UserState | null,
-    readonly interest: string | null,
+    readonly interestId: string | null,
     readonly limit: number,
     readonly offset: number,
   ) {}

--- a/src/app/application/user/query/listUser/ListUserQueryHandler.spec.ts
+++ b/src/app/application/user/query/listUser/ListUserQueryHandler.spec.ts
@@ -30,7 +30,7 @@ describe('ListUserQueryHandler', () => {
     let listView: UserListView;
 
     const state = UserState.UNDERGRADUATE;
-    const interest = '관심사';
+    const interestId = 'interestId';
     const limit = 5;
     const offset = 0;
 
@@ -40,21 +40,21 @@ describe('ListUserQueryHandler', () => {
     });
 
     test('파라미터를 의도대로 쿼리에 넘겨주어야 한다', async () => {
-      const query = new ListUserQuery(state, interest, limit, offset);
+      const query = new ListUserQuery(state, interestId, limit, offset);
 
       await listUserQueryHandler.execute(query);
 
       expect(userQuery.listUser).toBeCalledTimes(1);
       expect(userQuery.listUser).toBeCalledWith({
         state,
-        interest,
+        interestId,
         limit,
         offset,
       });
     });
 
     test('유저 목록 뷰를 의도대로 반환해야 한다', async () => {
-      const query = new ListUserQuery(state, interest, limit, offset);
+      const query = new ListUserQuery(state, interestId, limit, offset);
 
       const queryResult = await listUserQueryHandler.execute(query);
 

--- a/src/app/application/user/query/listUser/ListUserQueryHandler.ts
+++ b/src/app/application/user/query/listUser/ListUserQueryHandler.ts
@@ -19,11 +19,11 @@ export class ListUserQueryHandler
   ) {}
 
   async execute(query: ListUserQuery): Promise<ListUserQueryResult> {
-    const { state, interest, limit, offset } = query;
+    const { state, interestId, limit, offset } = query;
 
     const listView = await this.userQuery.listUser({
       state,
-      interest,
+      interestId,
       limit,
       offset,
     });


### PR DESCRIPTION
### 주요 변경 사항
<!-- 해당 PR로 변경되는 사항을 한 눈에 알기 쉽게 정리해주세요. -->

관심사의 id로 쿼리하도록 수정합니다.

### 변경 이유
<!-- 변경이 일어나는 이유를 한 눈에 알기 쉽게 정리해주세요. -->

관심사 문자열로 비교하는 것이 아니라 `UserInterest` 도메인 기준으로 쿼리할 것이기 때문에, `interest` 대신에 `interestId`를 받도록 수정합니다.